### PR TITLE
fix(cli): add the bin property to the package.json for global usage of the cli

### DIFF
--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -49,7 +49,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish updated packages
         run: |
-          npx lerna publish from-package --yes
+          npx lerna publish from-package --yes --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -49,7 +49,7 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       - name: Publish updated packages
         run: |
-          npx lerna publish from-package --yes --access public
+          npx lerna publish from-package --yes --no-private
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -24,16 +24,13 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Install dependencies
-        run: yarn install && npm i -g npm@latest
-
       - name: Setup Yarn
         run: |
           corepack enable
           yarn set version 1.22.22
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: yarn install && npm i -g npm@latest
 
       - name: Build the packages
         run: |

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "npmClient": "yarn"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
   "$schema": "node_modules/lerna/schemas/lerna-schema.json",
-  "version": "1.0.2",
+  "version": "1.0.0",
   "npmClient": "yarn"
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,6 +5,9 @@
   "main": "lib/index",
   "author": "Adam Billard",
   "license": "MIT",
+  "bin": {
+    "docker-watch": "lib/index.js"
+  },
   "files": [
     "lib",
     "package.json"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CLI for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",
@@ -15,7 +15,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@docker-watch/core": "^1.0.0",
+    "@docker-watch/core": "^1.0.1",
     "commander": "^13.1.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",
@@ -15,7 +15,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@docker-watch/core": "^1.0.1",
+    "@docker-watch/core": "^1.0.2",
     "commander": "^13.1.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CLI for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",
@@ -15,7 +15,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@docker-watch/core": "^1.0.0",
+    "@docker-watch/core": "^1.0.1",
     "commander": "^13.1.0"
   },
   "publishConfig": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/cli",
-  "version": "1.0.2",
+  "version": "1.0.0",
   "description": "CLI for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",
@@ -15,7 +15,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@docker-watch/core": "^1.0.2",
+    "@docker-watch/core": "^1.0.0",
     "commander": "^13.1.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/cli",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "CLI for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",
@@ -15,7 +15,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@docker-watch/core": "^1.0.1",
+    "@docker-watch/core": "^1.0.0",
     "commander": "^13.1.0"
   },
   "publishConfig": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/cli",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "CLI for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",
@@ -15,7 +15,7 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@docker-watch/core": "^1.0.1",
+    "@docker-watch/core": "^1.0.0",
     "commander": "^13.1.0"
   }
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/cli",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CLI for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/cli",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "CLI for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",
@@ -15,7 +15,10 @@
     "build": "tsc"
   },
   "dependencies": {
-    "@docker-watch/core": "^1.0.1",
+    "@docker-watch/core": "^1.0.0",
     "commander": "^13.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/core",
-  "version": "1.0.2",
+  "version": "1.0.0",
   "description": "Core logic for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/core",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Core logic for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",
@@ -21,5 +21,8 @@
   "devDependencies": {
     "@types/dockerode": "^3.3.34",
     "typed-emitter": "^2.1.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Core logic for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/core",
-  "version": "1.0.1",
+  "version": "1.0.0",
   "description": "Core logic for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@docker-watch/core",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Core logic for docker-watch",
   "main": "lib/index",
   "author": "Adam Billard",

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docker-watch/runner",
-    "version": "1.0.1",
+    "version": "1.0.0",
     "description": "Docker container to run docker-watch",
     "scripts": {
         "start": "node lib/index.js",
@@ -11,6 +11,9 @@
     "private": "true",
     "license": "MIT",
     "dependencies": {
-        "@docker-watch/core": "^1.0.1"
+        "@docker-watch/core": "^1.0.0"
+    },
+    "publishConfig": {
+        "access": "public"
     }
 }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docker-watch/runner",
-    "version": "1.0.1",
+    "version": "1.0.0",
     "description": "Docker container to run docker-watch",
     "scripts": {
         "start": "node lib/index.js",
@@ -11,7 +11,7 @@
     "private": "true",
     "license": "MIT",
     "dependencies": {
-        "@docker-watch/core": "^1.0.1"
+        "@docker-watch/core": "^1.0.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docker-watch/runner",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Docker container to run docker-watch",
     "scripts": {
         "start": "node lib/index.js",
@@ -11,6 +11,6 @@
     "private": "true",
     "license": "MIT",
     "dependencies": {
-        "@docker-watch/core": "^1.0.0"
+        "@docker-watch/core": "^1.0.1"
     }
 }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docker-watch/runner",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "description": "Docker container to run docker-watch",
     "scripts": {
         "start": "node lib/index.js",
@@ -11,6 +11,6 @@
     "private": "true",
     "license": "MIT",
     "dependencies": {
-        "@docker-watch/core": "^1.0.1"
+        "@docker-watch/core": "^1.0.2"
     }
 }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docker-watch/runner",
-    "version": "1.0.1",
+    "version": "1.0.0",
     "description": "Docker container to run docker-watch",
     "scripts": {
         "start": "node lib/index.js",
@@ -11,6 +11,6 @@
     "private": "true",
     "license": "MIT",
     "dependencies": {
-        "@docker-watch/core": "^1.0.1"
+        "@docker-watch/core": "^1.0.0"
     }
 }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docker-watch/runner",
-    "version": "1.0.2",
+    "version": "1.0.0",
     "description": "Docker container to run docker-watch",
     "scripts": {
         "start": "node lib/index.js",
@@ -11,6 +11,6 @@
     "private": "true",
     "license": "MIT",
     "dependencies": {
-        "@docker-watch/core": "^1.0.2"
+        "@docker-watch/core": "^1.0.0"
     }
 }

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@docker-watch/runner",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Docker container to run docker-watch",
     "scripts": {
         "start": "node lib/index.js",
@@ -11,7 +11,7 @@
     "private": "true",
     "license": "MIT",
     "dependencies": {
-        "@docker-watch/core": "^1.0.0"
+        "@docker-watch/core": "^1.0.1"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
Prior to this PR, docker-watch wasn't usable in the global path through the command "docker-watch". You would need to do npx @docker-watch/cli.